### PR TITLE
all inline functions as static

### DIFF
--- a/source/games/cps1.c
+++ b/source/games/cps1.c
@@ -1313,7 +1313,7 @@ static void cps1_find_last_sprite(void)    /* Find the offset of last sprite */
     cps1_last_sprite_offset=cps1_obj_size-8;
 }
 
-INLINE UINT8 *cps1_base(int offset,int boundary)
+static INLINE UINT8 *cps1_base(int offset,int boundary)
 {
 	int base=cps1_port[offset]*256;
 	/*
@@ -1971,7 +1971,7 @@ static int cps2_last_sprite_offset;     /* Offset of the last sprite */
 #define CPS2_OBJ_XOFFS	0x08	/* X offset (usually 0x0040) */
 #define CPS2_OBJ_YOFFS	0x0a	/* Y offset (always 0x0010) */
 
-INLINE UINT16 cps2_port(int offset)
+static INLINE UINT16 cps2_port(int offset)
 {
   return ReadWord(&cps2_output[offset]);
 }

--- a/source/games/f3system.c
+++ b/source/games/f3system.c
@@ -169,7 +169,7 @@ READ16_HANDLER(f3_68000_share_rw)
   return ReadWord68k(f3_shared_ram+(offset & 0xfff));
 }
 
-INLINE int convert_offset(int offset) {
+static INLINE convert_offset(int offset) {
   offset >>=1;
   offset &= 0xfff;
   return offset;

--- a/source/sdl/sasound.c
+++ b/source/sdl/sasound.c
@@ -699,7 +699,9 @@ static void my_callback(void *userdata, Uint8 *stream, int len)
 
     for (channel=0; channel<NUMVOICES; channel++) {
 	if (stream_buffer[channel]) {
-	    SDL_SemWait(sem[channel]);
+      int num_sem = channel;
+      while (!sem[num_sem]) num_sem--;
+	    SDL_SemWait(sem[num_sem]);
 	    // printf("my_callback chan %d len %d\n",channel,len);
 	    int volume = SampleVol[channel];
 	    int vol_l = (255-SamplePan[channel])*volume/255;
@@ -716,7 +718,7 @@ static void my_callback(void *userdata, Uint8 *stream, int len)
 		    stream_update_channel(channel, len/2-stream_buffer_pos[channel]);
 		else {
 		    print_debug("buffer underrun channel %d and no callback\n",channel);
-		    SDL_SemPost(sem[channel]);
+		    SDL_SemPost(sem[num_sem]);
 		    continue;
 		}
 	    }
@@ -757,7 +759,7 @@ static void my_callback(void *userdata, Uint8 *stream, int len)
 		memcpy(stream_buffer[channel],stream_buffer[channel]+len,stream_buffer_pos[channel]*2-len);
 		stream_buffer_pos[channel] -= len/2;
 	    }
-	    SDL_SemPost(sem[channel]);
+	    SDL_SemPost(sem[num_sem]);
 	}
     }
 

--- a/source/sound/es5506.c
+++ b/source/sound/es5506.c
@@ -153,7 +153,7 @@ static FILE *eslog;
 
 ***********************************************************************************************/
 
-INLINE static void update_irq_state(struct ES5506Chip *chip)
+static INLINE void update_irq_state(struct ES5506Chip *chip)
 {
 	/* ES5505/6 irq line has been set high - inform the host */
 	if (chip->irq_callback)
@@ -1018,7 +1018,7 @@ void ES5506_sh_stop(void)
 
 ***********************************************************************************************/
 
-INLINE void es5506_reg_write_low(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset, UINT32 data)
+static INLINE void es5506_reg_write_low(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset, UINT32 data)
 {
   //fprintf(stderr,"ess_reg_write_low %x %d\n",offset,data);
   switch (offset)
@@ -1094,7 +1094,7 @@ INLINE void es5506_reg_write_low(struct ES5506Chip *chip, struct ES5506Voice *vo
 }
 
 
-INLINE void es5506_reg_write_high(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset, UINT32 data)
+static INLINE void es5506_reg_write_high(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset, UINT32 data)
 {
   //fprintf(stderr,"ess_reg_write_high %x %d\n",offset,data);
 	switch (offset)
@@ -1162,7 +1162,7 @@ INLINE void es5506_reg_write_high(struct ES5506Chip *chip, struct ES5506Voice *v
 	}
 }
 
-INLINE void es5506_reg_write_test(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset, UINT32 data)
+static INLINE void es5506_reg_write_test(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset, UINT32 data)
 {
   switch (offset)
     {
@@ -1278,7 +1278,7 @@ static void es5506_reg_write(struct ES5506Chip *chip, offs_t offset, data8_t dat
 
 ***********************************************************************************************/
 
-INLINE UINT32 es5506_reg_read_low(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset)
+static INLINE UINT32 es5506_reg_read_low(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset)
 {
 	UINT32 result = 0;
 
@@ -1356,7 +1356,7 @@ INLINE UINT32 es5506_reg_read_low(struct ES5506Chip *chip, struct ES5506Voice *v
 }
 
 
-INLINE UINT32 es5506_reg_read_high(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset)
+static INLINE UINT32 es5506_reg_read_high(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset)
 {
 	UINT32 result = 0;
 
@@ -1433,7 +1433,7 @@ INLINE UINT32 es5506_reg_read_high(struct ES5506Chip *chip, struct ES5506Voice *
 	return result;
 }
 
-INLINE UINT32 es5506_reg_read_test(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset)
+static INLINE UINT32 es5506_reg_read_test(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset)
 {
 	UINT32 result = 0;
 
@@ -1603,7 +1603,7 @@ void ES5505_sh_stop(void)
 
 ***********************************************************************************************/
 
-static inline void es5505_reg_write_low(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset, UINT16 data, UINT16 mem_mask)
+static INLINE void es5505_reg_write_low(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset, UINT16 data, UINT16 mem_mask)
 {
   switch (offset)
     {
@@ -1718,7 +1718,7 @@ static inline void es5505_reg_write_low(struct ES5506Chip *chip, struct ES5506Vo
 }
 
 
-static inline void es5505_reg_write_high(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset, UINT16 data, UINT16 mem_mask)
+static INLINE void es5505_reg_write_high(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset, UINT16 data, UINT16 mem_mask)
 {
   //fprintf(stderr,"reg_write_high %x\n",offset);
   switch (offset)
@@ -1793,7 +1793,7 @@ static inline void es5505_reg_write_high(struct ES5506Chip *chip, struct ES5506V
 }
 
 
-static inline void es5505_reg_write_test(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset, UINT16 data, UINT16 mem_mask)
+static INLINE void es5505_reg_write_test(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset, UINT16 data, UINT16 mem_mask)
 {
   //fprintf(stderr,"writetest offset %x data %x\n",offset,data);
   switch (offset)
@@ -1864,7 +1864,7 @@ static void es5505_reg_write(struct ES5506Chip *chip, offs_t offset, data16_t da
 
 ***********************************************************************************************/
 
-INLINE UINT16 es5505_reg_read_low(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset)
+static INLINE UINT16 es5505_reg_read_low(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset)
 {
   UINT16 result = 0;
 
@@ -1944,7 +1944,7 @@ INLINE UINT16 es5505_reg_read_low(struct ES5506Chip *chip, struct ES5506Voice *v
 }
 
 
-INLINE UINT16 es5505_reg_read_high(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset)
+static INLINE UINT16 es5505_reg_read_high(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset)
 {
   UINT16 result = 0;
 
@@ -2017,7 +2017,7 @@ INLINE UINT16 es5505_reg_read_high(struct ES5506Chip *chip, struct ES5506Voice *
 }
 
 
-INLINE UINT16 es5505_reg_read_test(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset)
+static INLINE UINT16 es5505_reg_read_test(struct ES5506Chip *chip, struct ES5506Voice *voice, offs_t offset)
 {
   UINT16 result = 0;
 

--- a/source/sound/fm.c
+++ b/source/sound/fm.c
@@ -1096,7 +1096,7 @@ static INLINE void set_ar_ksr(UINT8 type,FM_CH *CH,FM_SLOT *SLOT,int v)
 	}
 
 /* set decay rate */
-INLINE void set_dr(UINT8 type, FM_SLOT *SLOT,int v)
+static INLINE void set_dr(UINT8 type, FM_SLOT *SLOT,int v)
 {
 	SLOT->d1r = (v&0x1f) ? 32 + ((v&0x1f)<<1) : 0;
 
@@ -1113,7 +1113,7 @@ INLINE void set_dr(UINT8 type, FM_SLOT *SLOT,int v)
 }
 
 /* set sustain rate */
-INLINE void set_sr(UINT8 type, FM_SLOT *SLOT,int v)
+static INLINE void set_sr(UINT8 type, FM_SLOT *SLOT,int v)
 {
 	SLOT->d2r = (v&0x1f) ? 32 + ((v&0x1f)<<1) : 0;
 
@@ -1129,7 +1129,7 @@ INLINE void set_sr(UINT8 type, FM_SLOT *SLOT,int v)
 }
 
 /* set release rate */
-INLINE void set_sl_rr(UINT8 type, FM_SLOT *SLOT,int v)
+static INLINE void set_sl_rr(UINT8 type, FM_SLOT *SLOT,int v)
 {
 	SLOT->sl = sl_table[ v>>4 ];
 
@@ -1148,7 +1148,7 @@ INLINE void set_sl_rr(UINT8 type, FM_SLOT *SLOT,int v)
 
 
 
-INLINE signed int op_calc(UINT32 phase, unsigned int env, signed int pm)
+static INLINE signed int op_calc(UINT32 phase, unsigned int env, signed int pm)
 {
 	UINT32 p;
 
@@ -1171,7 +1171,7 @@ static INLINE signed int op_calc1(UINT32 phase, unsigned int env, signed int pm)
 }
 
 /* advance LFO to next sample */
-INLINE void advance_lfo(FM_OPN *OPN)
+static INLINE void advance_lfo(FM_OPN *OPN)
 {
 	UINT8 pos;
 

--- a/source/sound/ymz280b.c
+++ b/source/sound/ymz280b.c
@@ -86,7 +86,7 @@ static int diff_lookup[16];
 
 
 
-INLINE void update_irq_state(struct YMZ280BChip *chip)
+static INLINE void update_irq_state(struct YMZ280BChip *chip)
 {
 	int irq_bits = chip->status_register & chip->irq_mask;
 
@@ -110,7 +110,7 @@ INLINE void update_irq_state(struct YMZ280BChip *chip)
 }
 
 
-INLINE void update_step(struct YMZ280BChip *chip, struct YMZ280BVoice *voice)
+static INLINE void update_step(struct YMZ280BChip *chip, struct YMZ280BVoice *voice)
 {
 	double frequency;
 
@@ -130,7 +130,7 @@ INLINE void update_step(struct YMZ280BChip *chip, struct YMZ280BVoice *voice)
 }
 
 
-INLINE void update_volumes(struct YMZ280BVoice *voice)
+static INLINE void update_volumes(struct YMZ280BVoice *voice)
 {
   if (voice->pan == 8)
 	{


### PR DESCRIPTION
pour la compile et le link propre sur os x. Tous les inline sont maintenant en static. Ca marche. Et ca me permet d'avoir tous les messages de debug !
