### PR TITLE
Fix str(n)cpy source/target overlap issue

### DIFF
--- a/source/raine.c
+++ b/source/raine.c
@@ -331,7 +331,7 @@ int main(int argc,char *argv[])
    load_main_config();
 
    // RAINE GUI (Allegro...)
-   strncpy(language,	 raine_get_config_string( "General", "language", language), 2);
+   strncpy(language,	 raine_get_config_string( "General", "language", ""), 2);
    language[2] = 0;
    init_lang();
 
@@ -401,9 +401,16 @@ int main(int argc,char *argv[])
    dir_cfg.long_file_names	= raine_get_config_int( "Directories",  "long_file_names",      1);
 #endif
 
-   strcpy(dir_cfg.screen_dir,	 raine_get_config_string( "Directories", "screenshots",   dir_cfg.screen_dir));
-   strcpy(dir_cfg.emudx_dir,	 raine_get_config_string( "Directories", "emudx",   dir_cfg.emudx_dir));
-   strcpy(dir_cfg.artwork_dir,	 raine_get_config_string( "Directories", "artwork",   dir_cfg.artwork_dir));
+   {
+     char *t;
+     t = raine_get_config_string("Directories", "screenshots", dir_cfg.screen_dir);
+     if (t != dir_cfg.screen_dir) strcpy(dir_cfg.screen_dir, t);
+     t = raine_get_config_string("Directories", "emudx", dir_cfg.emudx_dir);
+     if (t != dir_cfg.emudx_dir) strcpy(dir_cfg.emudx_dir, t);
+     t = raine_get_config_string("Directories", "artwork", dir_cfg.artwork_dir);
+     if (t != dir_cfg.artwork_dir) strcpy(dir_cfg.artwork_dir, t);
+   }
+
    i=0;
    do {
      alloc_romdir(i);


### PR DESCRIPTION
With recent versions of OS X, fresh installation of raine crashes on startup. It seems overlapping source/target pointer has not been allowed [since Mavericks](http://lists.gnu.org/archive/html/bug-bash/2013-07/msg00011.html).

```
Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_CRASH (SIGABRT)
Exception Codes:       0x0000000000000000, 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY

Application Specific Information:
detected source and destination buffer overlap

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib          0x989ad58a __pthread_kill + 10
1   libsystem_pthread.dylib         0x97f2a448 pthread_kill + 101
2   libsystem_c.dylib               0x9d046c34 abort + 156
3   libsystem_c.dylib               0x9d046d7f abort_report_np + 82
4   libsystem_c.dylib               0x9d075ad1 __chk_fail + 54
5   libsystem_c.dylib               0x9d075ae8 __chk_fail_overlap + 23
6   libsystem_c.dylib               0x9d075b23 __chk_overlap + 59
7   libsystem_c.dylib               0x9d075ca0 __strncpy_chk + 91
8   raine                           0x004eba2b SDL_main + 1739 (raine.c:334)
9   raine                           0x0050ac77 -[SDLMain applicationDidFinishLaunching:] + 103 (SDLMain.m:300)
10  com.apple.Foundation            0x924f92f2 __57-[NSNotificationCenter addObserver:selector:name:object:]_block_invoke_2 + 50
11  com.apple.CoreFoundation        0x97331d14 __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 20
12  com.apple.CoreFoundation        0x97331c5b ___CFXRegistrationPost_block_invoke + 75
13  com.apple.CoreFoundation        0x9733122c _CFXRegistrationPost + 460
14  com.apple.CoreFoundation        0x97330f66 ___CFXNotificationPost_block_invoke + 54
15  com.apple.CoreFoundation        0x9732a9f3 -[_CFXNotificationRegistrar find:object:observer:enumerator:] + 1715
16  com.apple.CoreFoundation        0x97206e22 _CFXNotificationPost + 626
17  com.apple.Foundation            0x923741c5 -[NSNotificationCenter postNotificationName:object:userInfo:] + 92
18  com.apple.AppKit                0x9a43c574 -[NSApplication _postDidFinishNotification] + 436
19  com.apple.AppKit                0x9a43c22e -[NSApplication _sendFinishLaunchingNotification] + 249
20  com.apple.AppKit                0x9a439146 -[NSApplication(NSAppleEventHandling) _handleAEOpenEvent:] + 783
21  com.apple.AppKit                0x9a438a9b -[NSApplication(NSAppleEventHandling) _handleCoreEvent:withReplyEvent:] + 291
22  libobjc.A.dylib                 0x98e82db2 -[NSObject performSelector:withObject:withObject:] + 84
23  com.apple.Foundation            0x923a8e78 __76-[NSAppleEventManager setEventHandler:andSelector:forEventClass:andEventID:]_block_invoke + 118
24  com.apple.Foundation            0x923a89dd -[NSAppleEventManager dispatchRawAppleEvent:withRawReply:handlerRefCon:] + 451
25  com.apple.Foundation            0x923a87d8 _NSAppleEventManagerGenericHandler + 211
26  com.apple.AE                    0x9d0b9251 aeDispatchAppleEvent(AEDesc const*, AEDesc*, unsigned long, unsigned char*) + 595
27  com.apple.AE                    0x9d08ac75 dispatchEventAndSendReply(AEDesc const*, AEDesc*) + 44
28  com.apple.AE                    0x9d08ab88 aeProcessAppleEvent + 299
29  com.apple.HIToolbox             0x951d785a AEProcessAppleEvent + 55
30  com.apple.AppKit                0x9a432a64 _DPSNextEvent + 2415
31  com.apple.AppKit                0x9a83d0b0 -[NSApplication _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1057
32  com.apple.AppKit                0x9a431f8b -[NSApplication nextEventMatchingMask:untilDate:inMode:dequeue:] + 121
33  com.apple.AppKit                0x9a42712f -[NSApplication run] + 1063
34  raine                           0x0050b157 CustomApplicationMain + 487 (SDLMain.m:229)
35  raine                           0x0050af62 main + 306 (SDLMain.m:377)
36  libdyld.dylib                   0x9e3886ad start + 1
```

This PR contains a naive but working fix that prevents default string of `raine_get_config_string()` from rolling over to the destination while the same pointer already plugged in the source.
