### PR TITLE
fix ambiguous abs() calls

### DIFF
--- a/source/sdl/console/exec.cpp
+++ b/source/sdl/console/exec.cpp
@@ -73,7 +73,7 @@ void do_break(int argc, char **argv) {
   } else {
     int adr = parse(argv[1]),n;
     for (n=0; n<used_break; n++) {
-      if (abs(adr-breakp[n].adr)<2) {
+      if (abs(adr-(int)breakp[n].adr)<2) {
 	if (cons) cons->print("already have a breakpoint at %x",breakp[n].adr);
 	return;
       }

--- a/source/sdl/gui/tfont.cpp
+++ b/source/sdl/gui/tfont.cpp
@@ -73,14 +73,14 @@ void TFont::select_ideal_font(int ideal_width, int ideal_height) {
     // 1st look for height
     while ((entry = readdir(dir))) {
       get_font_dimensions(entry->d_name,&w,&h);
-      if (abs(h-ideal_height) < abs(besth - ideal_height))
+      if (abs((int)h-ideal_height) < abs((int)besth - ideal_height))
 	besth = h;
     }
     rewinddir(dir);
     // Now look for the best width with this height
     while ((entry = readdir(dir))) {
       get_font_dimensions(entry->d_name,&w,&h);
-      if (h == besth && (abs(w-ideal_width) < abs(bestw-ideal_width))) {
+      if (h == besth && (abs((int)w-ideal_width) < abs((int)bestw-ideal_width))) {
 	strcpy(selected, entry->d_name);
 	bestw = w;
       }


### PR DESCRIPTION
Compilation fails on macOS 10.12 and 10.13 with the latest system compilers (from Xcode 9), because of ambiguous calls to `abs()` with `unsigned int` arguments.