### PR TITLE
fix: Game screen in opengl linux

### DIFF
--- a/source/sdl/blit.c
+++ b/source/sdl/blit.c
@@ -314,6 +314,8 @@ void ReClipScreen(void)
 
   // GameScreen.xview = oldxview;
   // GameScreen.yview = oldyview;
+  if (sdl_screen->flags & SDL_OPENGL)
+      opengl_reshape(sdl_screen->w,sdl_screen->h);
 }
 
 void DrawPaused(void)


### PR DESCRIPTION
This code was removed, c1043dffbcd7cee112c800f8b460f5b1b1fc151e however, when running some NeoGeoCD games (not all of them) the screen is distorted, you need to access Raine's menu and return to the game so that everything goes back to normal.
![Captura de tela em 2020-03-27 07-06-30](https://user-images.githubusercontent.com/47663685/77731026-fd928800-6ff9-11ea-84a7-384d2dd49cd0.png)
