### PR TITLE
Update to more texts in the GUI + repositioning of the Game command list option

### DIFF
--- a/source/sdl/dialogs/game_selection.cpp
+++ b/source/sdl/dialogs/game_selection.cpp
@@ -106,14 +106,14 @@ static int do_recent(int sel) {
 	for (n=0; n<game_count; n++)
 	    if (game_list[n]->nb_loaded) nb_most++;
 	if (nb_most == 0) {
-	    MessageBox("Error","No most played game yet","ok");
+	    MessageBox("Error","No most played game yet","OK");
 	    return 0;
 	}
     } else {
 	for (n=0; n<game_count; n++)
 	    if (game_list[n]->last_played) nb_most++;
 	if (nb_most == 0) {
-	    MessageBox("Error","No recent game yet\nIf you use the init command in Options if you\nhave some old data files in savedata","ok");
+	    MessageBox("Error","No recent game yet\nIf you use the init command in Options if you\nhave some old data files in savedata","OK");
 	    return 0;
 	}
     }
@@ -437,7 +437,7 @@ void TGame_sel::draw_top_frame() {
   int fw = HMARGIN;
   switch(game_list_mode) {
     case 0: s = _("All"); break;
-    case 1: s = _("Avail"); break;
+    case 1: s = _("Available"); break;
     case 2: s = _("Missing"); break;
   }
   snprintf(mytitle,80,"%s %d",s,nb_disp_items);
@@ -453,7 +453,7 @@ void TGame_sel::draw_top_frame() {
 
 void TGame_sel::draw_bot_frame() {
   if (!w_year) {
-    char *year_string = _("Year : 2006");
+    char *year_string = _("Year: 2006");
     font->dimensions(year_string,&w_year,&h_year);
     h_bot = h_year*2;
   }
@@ -464,12 +464,12 @@ void TGame_sel::draw_bot_frame() {
   boxColor(sdl_screen,0,base,sdl_screen->w,sdl_screen->h,bg_frame_gfx);
 #endif
   char game_string[140],year_string[80],category_string[80],company_string[100];
-  snprintf(game_string,140,_("Game : %s"),(sel >= 0 ? game_list[sel]->long_name : "-"));
-  snprintf(company_string,100,_("Company : %s"),(sel >= 0 ? game_company_name(game_list[sel]->company_id) : "-"));
+  snprintf(game_string,140,_("Game: %s"),(sel >= 0 ? game_list[sel]->long_name : "-"));
+  snprintf(company_string,100,_("Company: %s"),(sel >= 0 ? game_company_name(game_list[sel]->company_id) : "-"));
   company_string[99] = 0;
   if (sel >= 0) {
-    snprintf(year_string,80,_("Year : %d"),game_list[sel]->year);
-    sprintf(category_string,_("Category : "));
+    snprintf(year_string,80,_("Year: %d"),game_list[sel]->year);
+    sprintf(category_string,_("Category: "));
     int n;
     for (n=1; n<=NB_GAME_TYPE; n++) {
       if (game_list[sel]->flags & (1<<(n-1))) {
@@ -477,8 +477,8 @@ void TGame_sel::draw_bot_frame() {
       }
     }
   } else {
-    sprintf(year_string,_("Year : -"));
-    sprintf(category_string,_("Category : -"));
+    sprintf(year_string,_("Year: -"));
+    sprintf(category_string,_("Category: -"));
   }
   int fw = HMARGIN;
   font->put_string(fw,base,game_string,fg_frame,bg_frame);

--- a/source/sdl/dialogs/neocd_options.cpp
+++ b/source/sdl/dialogs/neocd_options.cpp
@@ -159,7 +159,7 @@ static int select_neocd_bios(int sel) {
 	strcpy(path,".");
 
     char *exts[] = { "bin", "zip", NULL };
-    fsel(path,exts,neocd_bios_file,"Find NeoCD bios");
+    fsel(path,exts,neocd_bios_file,"Find Neo-Geo CD BIOS");
     if (*neocd_bios_file && is_neocd()) {
 	if (neocd_bios) {
 	    free(neocd_bios);

--- a/source/sdl/dialogs/romdirs.cpp
+++ b/source/sdl/dialogs/romdirs.cpp
@@ -50,7 +50,7 @@ int do_romdir(int sel) {
     menu[0].label = _("Add ROM directory...");
     menu[0].menu_func = &add_dir;
 
-    TMenu *mbox = new TMenu(_("rom dirs"),menu);
+    TMenu *mbox = new TMenu(_("ROM directories"),menu);
     mbox->execute();
     delete mbox;
     free(menu);

--- a/source/sdl/gui.cpp
+++ b/source/sdl/gui.cpp
@@ -513,6 +513,7 @@ static menu_item_t main_items[] =
 {
 { _("Play game"), &play_game, },
 { _("Game options"), &do_game_options },
+{ _("Game command list"), &show_moves },
 { _("Region"), &set_region, },
 { _("Action Replay cheats"), &do_cheats, },
 { _("Dipswitches"), &do_dlg_dsw, },
@@ -526,7 +527,6 @@ static menu_item_t main_items[] =
 { _("GUI options"), &do_gui_options },
 { _("Inputs"), &do_controls },
 { _("About..."), &do_about,},
-{ _("Show game command list"), &show_moves },
 #ifdef HAS_CONSOLE
 { _("Console"), &do_console, },
 #endif

--- a/source/sdl/gui.cpp
+++ b/source/sdl/gui.cpp
@@ -514,7 +514,7 @@ static menu_item_t main_items[] =
 { _("Play game"), &play_game, },
 { _("Game options"), &do_game_options },
 { _("Region"), &set_region, },
-{ _("Action replay cheats"), &do_cheats, },
+{ _("Action Replay cheats"), &do_cheats, },
 { _("Dipswitches"), &do_dlg_dsw, },
 { _("Change/Load game"), &do_game_sel },
 #if HAS_NEO
@@ -523,10 +523,10 @@ static menu_item_t main_items[] =
 #endif
 { _("Video options"), &do_video_options },
 { _("Sound options"), &do_sound_options },
-{ _("Options"), &do_gui_options },
+{ _("GUI options"), &do_gui_options },
 { _("Inputs"), &do_controls },
 { _("About..."), &do_about,},
-{ _("Show command.dat info"), &show_moves },
+{ _("Show game command list"), &show_moves },
 #ifdef HAS_CONSOLE
 { _("Console"), &do_console, },
 #endif


### PR DESCRIPTION
Update gui.cpp
Capitalized "replay" to match the original product name, renamed "Show command.dat info" to "Show game command list" to use a term more commonly seen in fighting games, and renamed "Options" to "GUI options" to respect the title parallelism in "Sound options", "Video options", "Neo-Geo options" and "Game options".

Update romdirs.cpp
Renamed the title menu "rom dirs" to "ROM directories".

Update neocd_options.cpp
Renamed title menu "Find NeoCD bios" to "Find Neo-Geo CD BIOS".

Update game_selection.cpp
Capitalized "ok" in the new error messages showed in the new "Recent" and "Most played" games lists, removed the abbreviation in "Avail" and the space between the word and the colon in the game information categories (year, category, game and company) to match the English standard typing rules.

Update gui.cpp
Removed "Show" from "Show game command list" to avoid redundancy and to reduce the number of characters possibly used in translations. Re-positioned the new "Game command list" option below "Game options" to better group it with similar options related to the game.