### PR TITLE
Minor text revisions

### DIFF
--- a/source/sdl/dialogs/game_selection.cpp
+++ b/source/sdl/dialogs/game_selection.cpp
@@ -113,7 +113,7 @@ static int do_recent(int sel) {
 	for (n=0; n<game_count; n++)
 	    if (game_list[n]->last_played) nb_most++;
 	if (nb_most == 0) {
-	    MessageBox("Error","No recent games yet\nIf you use the init command in Options if you\nhave some old data files in savedata","OK");
+	    MessageBox("Error","No recent games yet","OK");
 	    return 0;
 	}
     }
@@ -196,7 +196,7 @@ static menu_item_t header[] =
     {  _("-- Options --"), &do_options },
     { _("Recent games..."), &do_recent },
     { _("Most played games..."), do_recent },
-    { _("Preload ips dat file"), &do_preload_ips, },
+    { _("Preload IPS *.dat file"), &do_preload_ips, },
     { NULL },
 };
 

--- a/source/sdl/gui.cpp
+++ b/source/sdl/gui.cpp
@@ -768,7 +768,7 @@ int do_preload_ips(int sel) {
     char *res[10];
     memset(res,0,10*sizeof(char*));
     char *exts[] = { ".dat", NULL };
-    my_multi_fsel(get_shared("ips"),exts,res,10,_("Select IPS .dat file"));
+    my_multi_fsel(get_shared("ips"),exts,res,10,_("Select IPS *.dat file"));
     // Not very convenient : when the fsel is closed by esc, it just returns its last path in res
     // so the only way to test this is to test if res contains a directory, since directories can be opened as normal files in linux !
     struct stat stbuf;
@@ -800,7 +800,7 @@ static menu_item_t main_items[] =
 {
 { _("Play game"), &play_game, },
 { _("Game options"), &do_game_options },
-{ _("Game command list"), &show_moves },
+{ _("Game commands list"), &show_moves },
 { _("Game cheats"), &do_cheats, },
 { _("Apply IPS to ROM code"), &do_ips, },
 { _("Region"), &set_region, },


### PR DESCRIPTION
I capitalized the "ips" acronym in the game selection menu to match the other functions with this term in the GUI. I also added a * before the ".dat" file extension.
Other that, I fixed a string in the "No recent games yet" message and changed "Game command list" to "Game commands list" in the main menu, as per discussed here:
https://www.1emulation.com/forums/topic/36851-raine-0949-a-last-094-version/?do=findComment&comment=365759