### PR TITLE
Reorganize "Mute SFA3 announcer" in Sound options

### DIFF
--- a/source/sdl/dialogs/sound_options.cpp
+++ b/source/sdl/dialogs/sound_options.cpp
@@ -78,13 +78,13 @@ menu_item_t sound_menu[] =
   { _("Raw audio tracks format"), NULL, &neocd_cdda_format, 2, { AUDIO_S16LSB, AUDIO_S16MSB }, { _("Less significant byte"),_("Most significant byte") }},
   { _("Mute sound effects"), NULL, &mute_sfx, 2, { 0, 1 }, { _("No"), _("Yes") } },
   { _("Mute music"), NULL, &mute_music, 2, { 0, 1 }, { _("No"), _("Yes") } },
+  { _("Mute SFA3 announcer"), NULL, &mute_sfa3_speaker, 2, {0, 1}, { _("No"), _("Yes") } },
   { _("Default volumes"), &set_default_volumes },
 #endif
   { _("Record to raine_sound.wav"), NULL, &recording, 3, { 0, 1, 2 }, { _("No"), _("Without monitoring"), _("With monitoring") } },
 #if HAS_NEO
 { _("Sound commands..."), &do_sound_cmd },
 #endif
-{ _("Mute sfa3 announcer"), NULL, &mute_sfa3_speaker, 2, {0, 1}, { _("No"), _("Yes") } },
   { NULL },
 };
 

--- a/source/sdl/dialogs/sound_options.cpp
+++ b/source/sdl/dialogs/sound_options.cpp
@@ -83,7 +83,7 @@ menu_item_t sound_menu[] =
 #endif
   { _("Record to raine_sound.wav"), NULL, &recording, 3, { 0, 1, 2 }, { _("No"), _("Without monitoring"), _("With monitoring") } },
 #if HAS_NEO
-{ _("Sound commands..."), &do_sound_cmd },
+{ _("Sound associations..."), &do_sound_cmd },
 #endif
   { NULL },
 };


### PR DESCRIPTION
I grouped all the "mute" settings in the list to help with the visual organization of the menu and kept "Sound commands..." at the bottom for the users who were already used to going there for that setting. Also, "Sound commands..." is a sub-menu in Sound options, so it fits better placed at the end of the list, I suppose.

I also took the opportunity to capitalize the "sfa3" acronym as per discussed in the forum, here:
https://www.1emulation.com/forums/topic/36859-sharing-of-cheat-used-in-raine/?do=findComment&comment=366241 

I'm not sure if you will agree with that, but I'm using this pull request to commit it anyway and see what you think. Thank you in advance for your consideration.

**EDIT:** I renamed "Sound commands..." to "Sound associations..." to better describe what we mostly do with this option, which is to associate sound commands to external audio tracks, not simply check or play sound commands from a game. Thank you so much again for considering this another change too.