### PR TITLE
Changed "ISO" to "disc image" + translation corrections

### DIFF
--- a/locale/es.po
+++ b/locale/es.po
@@ -5586,7 +5586,7 @@ msgstr "Prueba de Sonido"
 
 #: source/sdl/dialogs/sound_commands.cpp:240
 msgid "Sound associations"
-msgstr "Asociacion de sonidos"
+msgstr "Asociaciones de sonido"
 
 #: source/sdl/dialogs/sound_commands.cpp:370
 msgid "Sound associations"
@@ -6332,8 +6332,8 @@ msgid "Upright Controls"
 msgstr "Controles Verticales"
 
 #: source/sdl/dialogs/video_options.cpp:226
-msgid "Use blending files (.bld)"
-msgstr "Usar archivos de blending (.bld)"
+msgid "Use blending files (*.bld)"
+msgstr "Usar archivos de blending (*.bld)"
 
 #: source/sdl/gui/menu.cpp:156
 msgid "Use custom mouse cursor"
@@ -6706,8 +6706,8 @@ msgstr "azul"
 
 #: source/neocd/cdrom.c:243
 #, fuzzy
-msgid "can't find ISO file"
-msgstr "no se puede encontrar archivo iso"
+msgid "Cannot find disc image file"
+msgstr "No se puede encontrar el archivo de imagen de disco"
 
 #: source/sdl/dialogs/colors.cpp:41
 msgid "color"

--- a/locale/es.po
+++ b/locale/es.po
@@ -2425,8 +2425,8 @@ msgstr "Sin poder encontrar pista de audio %d"
 #: source/neocd/iso.c:94
 #, c-format
 #, fuzzy
-msgid "Couldn't open ISO file:|%s"
-msgstr "Sin poder abrir archivo iso:|%s"
+msgid "Couldn't open disc image file:|%s"
+msgstr "Sin poder abrir archivo de imagen de disco:|%s"
 
 #: source/games/hyperpcb.c:539 source/games/seta.c:1802
 #: source/games/seta.c:2758

--- a/locale/french.po
+++ b/locale/french.po
@@ -6264,8 +6264,8 @@ msgid "Upright Controls"
 msgstr "Contrôles verticaux"
 
 #: source/sdl/dialogs/video_options.cpp:226
-msgid "Use blending files (.bld)"
-msgstr "Utiliser les fichiers de transparence (.bld)"
+msgid "Use blending files (*.bld)"
+msgstr "Utiliser les fichiers de transparence (*.bld)"
 
 #: source/sdl/gui/menu.cpp:156
 msgid "Use custom mouse cursor"
@@ -6629,8 +6629,8 @@ msgid "blue"
 msgstr "bleu"
 
 #: source/neocd/cdrom.c:243
-msgid "can't find ISO file"
-msgstr "Ne peut pas trouver le fichier ISO"
+msgid "Cannot find disc image file"
+msgstr "Ne peut pas trouver le fichier image du disque"
 
 #: source/sdl/dialogs/colors.cpp:41
 msgid "color"

--- a/locale/french.po
+++ b/locale/french.po
@@ -2405,8 +2405,8 @@ msgstr ""
 #: source/neocd/iso.c:94
 #, c-format
 #, fuzzy
-msgid "Couldn't open ISO file:|%s"
-msgstr ""
+msgid "Couldn't open disc image file:|%s"
+msgstr "N'a pas pu trouver le fichier image du disque:|%s"
 
 #: source/games/hyperpcb.c:539 source/games/seta.c:1802
 #: source/games/seta.c:2758

--- a/locale/it.po
+++ b/locale/it.po
@@ -6669,8 +6669,8 @@ msgid "Upright Controls"
 msgstr "Controlli verticali"
 
 #: source/sdl/dialogs/video_options.cpp:226
-msgid "Use blending files (.bld)"
-msgstr "Usa file per la trasparenza (Blend/.bld)"
+msgid "Use blending files (*.bld)"
+msgstr "Usa file per la trasparenza (Blend/*.bld)"
 
 #: source/sdl/gui/menu.cpp:156
 msgid "Use custom mouse cursor"
@@ -7060,8 +7060,8 @@ msgstr "blu"
 
 #: source/neocd/cdrom.c:243
 #, fuzzy
-msgid "can't find ISO file"
-msgstr "Non riesco a trovare il file ISO"
+msgid "Cannot find disc image file"
+msgstr "Non riesco a trovare il file immagine del disco"
 
 #: source/sdl/dialogs/colors.cpp:41
 msgid "color"

--- a/locale/it.po
+++ b/locale/it.po
@@ -2534,8 +2534,8 @@ msgstr "Non riesco a trovare la traccia audio %d"
 #: source/neocd/iso.c:94
 #, c-format
 #, fuzzy
-msgid "Couldn't open ISO file:|%s"
-msgstr "Non riesco ad aprire il file ISO:|%s"
+msgid "Couldn't open disc image file:|%s"
+msgstr "Non riesco ad aprire il file immagine del disco:|%s"
 
 # Daioh, Snow Bros, Winter Bobble
 #: source/games/hyperpcb.c:539 source/games/seta.c:1802

--- a/locale/pt_br.po
+++ b/locale/pt_br.po
@@ -5755,11 +5755,11 @@ msgstr "Associações de som"
 
 #: source/sdl/dialogs/sound_commands.cpp:370
 msgid "Sound associatons"
-msgstr "associações sonoras"
+msgstr "Associações de som"
 
 #: source/sdl/dialogs/sound_options.cpp:85
 msgid "Sound associations..."
-msgstr "Associações sonoras..."
+msgstr "Associações de som..."
 
 #: source/sdl/dialogs/sound_options.cpp:68
 msgid "Sound device"
@@ -6501,8 +6501,8 @@ msgid "Upright Controls"
 msgstr "Controles Verticais"
 
 #: source/sdl/dialogs/video_options.cpp:226
-msgid "Use blending files (.bld)"
-msgstr "Usar arquivos de mistura (.bld)"
+msgid "Use blending files (*.bld)"
+msgstr "Usar arquivos de mistura (*.bld)"
 
 #: source/sdl/gui/menu.cpp:156
 msgid "Use custom mouse cursor"
@@ -6867,8 +6867,8 @@ msgid "blue"
 msgstr "Azul"
 
 #: source/neocd/cdrom.c:243
-msgid "can't find ISO file"
-msgstr "Não pôde achar o arquivo iso"
+msgid "Cannot find disc image file"
+msgstr "Não pôde achar o arquivo de imagem do disco"
 
 #: source/sdl/dialogs/colors.cpp:41
 msgid "color"

--- a/locale/pt_br.po
+++ b/locale/pt_br.po
@@ -2484,8 +2484,8 @@ msgstr "Não pôde achar a faixa de áudio %d"
 
 #: source/neocd/iso.c:94
 #, c-format
-msgid "Couldn't open ISO file:|%s"
-msgstr "Não pôde abrir o arquivo ISO:|%s"
+msgid "Couldn't open disc image file:|%s"
+msgstr "Não pôde abrir o arquivo de imagem do disco:|%s"
 
 #: source/games/seta.c:1802 source/games/seta.c:2758
 #: source/games/hyperpcb.c:539

--- a/source/neocd/cdrom.c
+++ b/source/neocd/cdrom.c
@@ -240,7 +240,7 @@ static void handle_iso(char *start,char *cue) {
 	strcpy(&neocd_path[strlen(neocd_path)-3],ext);
     }
     if (!exists(neocd_path)) {
-	ErrorMsg(gettext("can't find ISO file"));
+	ErrorMsg(gettext("Cannot find disc image file"));
 	load_type = -1;
 	return;
     }

--- a/source/neocd/iso.c
+++ b/source/neocd/iso.c
@@ -91,7 +91,7 @@ static int find_file(char *iso, char *filename, int *size, int *start) {
   FILE *f = myopen(iso,"rb");
   if (!f) {
     char msg[256];
-    sprintf(msg,_("Couldn't open ISO file:|%s"),iso);
+    sprintf(msg,_("Couldn't open disc image file:|%s"),iso);
     MessageBox(gettext("Error"),msg,gettext("Ok"));
     return 0;
   }

--- a/source/neocd/neocd.c
+++ b/source/neocd/neocd.c
@@ -1516,7 +1516,7 @@ static struct ROMSW_DATA romsw_data_neocd[] =
   // regions with the neocdz bios, but they are read by almost all the games
   // from the neo soft dips. The only game which is an exception afaik is
   // kof95.
-  { "Portuguese (kof95, others ?)", 3 },
+  { "Brazil (KOF'95, others..?)", 3 },
   { NULL,                    0    },
 };
 
@@ -5362,7 +5362,7 @@ void execute_neocd() {
    * the idea is to detect when the hblank interrupt is needed (raster_frame)
    * and to change the handling accordingly to save cycles.
    * Not sure this thing is 100% correct */
-  // 7db0(a5) testé par futsal ???
+  // 7db0(a5) testï¿½ par futsal ???
   // WriteWord(&RAM[0x10fe80],0xffff);
 
   // lab_0432 = cd_test ???


### PR DESCRIPTION
Changed "ISO" for "disc image" to include other file formats for NGCD game disc copies as per discussed here:
https://github.com/zelurker/raine/pull/62

The current *.po translation files in the code have also been reviewed to incorporate this change. I also made a few corrections in the Spanish and Brazilian Portuguese translations, though I think the Spanish translation needs an overall revision.

I used https://www.deepl.com/translator to help me with the translated words. I hope the results are good.