### PR TITLE
Update to the translation files for previous text revision

### DIFF
--- a/locale/es.po
+++ b/locale/es.po
@@ -3455,8 +3455,8 @@ msgid "Game Type"
 msgstr "Tipo de Juego"
 
 #: source/sdl/gui.cpp:516
-msgid "Game command list"
-msgstr "Mostrar info de command.dat"
+msgid "Game commands list"
+msgstr "Lista de comandos del juego"
 
 #: source/demos.c:316
 msgid "Game does not support Loading."

--- a/locale/french.po
+++ b/locale/french.po
@@ -3426,8 +3426,8 @@ msgid "Game Type"
 msgstr ""
 
 #: source/sdl/gui.cpp:516
-msgid "Game command list"
-msgstr "Montrer les infos command.dat"
+msgid "Game commands list"
+msgstr "Liste des commandes de jeu"
 
 #: source/demos.c:316
 msgid "Game does not support Loading."

--- a/locale/it.po
+++ b/locale/it.po
@@ -3629,8 +3629,8 @@ msgid "Game Type"
 msgstr "Tipo di gioco"
 
 #: source/sdl/gui.cpp:516
-msgid "Game command list"
-msgstr "Informazioni mosse speciali..."
+msgid "Game commands list"
+msgstr "Elenco dei comandi di gioco"
 
 #: source/demos.c:316
 msgid "Game does not support Loading."

--- a/locale/pt_br.po
+++ b/locale/pt_br.po
@@ -3537,7 +3537,7 @@ msgid "Game cheats"
 msgstr "Trapaças do jogo"
 
 #: source/sdl/gui.cpp:525
-msgid "Game command list"
+msgid "Game commands list"
 msgstr "Lista de comandos do jogo"
 
 #: source/demos.c:316


### PR DESCRIPTION
The translation files were updated to work with a previous text revision to the "Game command list" option, which became "Game commands list" in a recent update.

I also updated the translated texts for this string in the French, Italian and Spanish translations, which were still using the old text "Show command.dat info...".

I used www.deepl.com to help me with the translated texts. I hope the results are good.