### PR TITLE
Better placement for the Save state and Load state functions in Game options

### DIFF
--- a/locale/es.po
+++ b/locale/es.po
@@ -5229,7 +5229,7 @@ msgstr "Reiniciar CPS a valor por defecto del driver"
 msgid "Reset game"
 msgstr "Reiniciar juego"
 
-#: source/sdl/dialogs/game_options.cpp:233
+#: source/sdl/dialogs/game_options.cpp:235
 msgid "Reset game hardware"
 msgstr "Reiniciar hardware de juego"
 
@@ -5390,7 +5390,7 @@ msgid "Save per game screen settings"
 msgstr "Salvar captura de pantalla opengl"
 
 #: source/sdl/dialogs/game_options.cpp:193
-#: source/sdl/dialogs/game_options.cpp:235 source/sdl/control.c:681
+#: source/sdl/dialogs/game_options.cpp:233 source/sdl/control.c:681
 msgid "Save state"
 msgstr "Salvar juego"
 

--- a/locale/french.po
+++ b/locale/french.po
@@ -5180,7 +5180,7 @@ msgstr "Remettre les FPS à la valeur par défaut"
 msgid "Reset game"
 msgstr "Reset du jeu"
 
-#: source/sdl/dialogs/game_options.cpp:233
+#: source/sdl/dialogs/game_options.cpp:235
 msgid "Reset game hardware"
 msgstr "Reset matériel"
 
@@ -5337,7 +5337,7 @@ msgid "Save per game screen settings"
 msgstr "Chaque jeu a ses paramètres vidéo"
 
 #: source/sdl/dialogs/game_options.cpp:193
-#: source/sdl/dialogs/game_options.cpp:235 source/sdl/control.c:681
+#: source/sdl/dialogs/game_options.cpp:233 source/sdl/control.c:681
 msgid "Save state"
 msgstr "Sauver le jeu"
 

--- a/locale/it.po
+++ b/locale/it.po
@@ -5476,7 +5476,7 @@ msgid "Reset game"
 msgstr "Riavvia gioco"
 
 # ------------------------------ GAME OPTIONS ------------------------------
-#: source/sdl/dialogs/game_options.cpp:233
+#: source/sdl/dialogs/game_options.cpp:235
 msgid "Reset game hardware"
 msgstr "Riavvia l'hardware del gioco"
 
@@ -5646,7 +5646,7 @@ msgid "Save per game screen settings"
 msgstr "Salva impostaz. video per ogni gioco"
 
 #: source/sdl/dialogs/game_options.cpp:193
-#: source/sdl/dialogs/game_options.cpp:235 source/sdl/control.c:681
+#: source/sdl/dialogs/game_options.cpp:233 source/sdl/control.c:681
 msgid "Save state"
 msgstr "Salva gioco"
 

--- a/locale/pt_br.po
+++ b/locale/pt_br.po
@@ -5391,7 +5391,7 @@ msgstr "Resetar os FPS pro valor padrão do driver"
 msgid "Reset game"
 msgstr "Resetar jogo"
 
-#: source/sdl/dialogs/game_options.cpp:233
+#: source/sdl/dialogs/game_options.cpp:235
 msgid "Reset game hardware"
 msgstr "Resetar o hardware do jogo"
 
@@ -5548,7 +5548,7 @@ msgid "Save per game screen settings"
 msgstr "Salvar as configurações da tela por jogo"
 
 #: source/sdl/dialogs/game_options.cpp:193
-#: source/sdl/dialogs/game_options.cpp:235 source/sdl/control.c:681
+#: source/sdl/dialogs/game_options.cpp:233 source/sdl/control.c:681
 msgid "Save state"
 msgstr "Save state"
 

--- a/source/sdl/dialogs/game_options.cpp
+++ b/source/sdl/dialogs/game_options.cpp
@@ -230,9 +230,9 @@ static int reset_fps(int sel) {
 
 static menu_item_t game_options[] =
 {
-  { _("Reset game hardware"), &my_reset },
-  { _("Load state"), &my_load },
   { _("Save state"), &my_save },
+  { _("Load state"), &my_load },
+  { _("Reset game hardware"), &my_reset },
   { _("Graphical layers..."), &graphical_layers },
 #if SDL==1
   { _("Sprite viewer"), &sprite_viewer },


### PR DESCRIPTION
Save state and Load state are now in the top of the Game options menu for quicker and easier access through the graphical user interface.

Sometimes we may be playing away from the keyboard and/or may not have enough buttons in the controller to bind other emulation functions such as Save and Load state, so we rely on the graphical user interface for that. Generally arcade games are very unbalanced in terms of difficulty so we may need to do a lot of save and load states in order to beat the game. If those functions are easier to access through the graphical interface, this job becomes quicker for the user, which is what happens when we place the Save/Load functions in the top of a menu. The "Reset game hardware" function is a less frequently used option when playing so it can safely be moved down a little in the menu.

I changed the line reference to the code in the translation files, but I'm not sure if this is enough to fix them.

Thank you so much in advance for considering this change.