### PR TITLE
Update samsho2pe to version 2.1 (latest June 2024 revision)

### DIFF
--- a/source/games/neogeo.c
+++ b/source/games/neogeo.c
@@ -1264,13 +1264,13 @@ CLNEI( samsho2, neogeo, "Samurai Shodown II / Shin Samurai Spirits - Haohmaru ji
 
 static struct ROM_INFO rom_samsho2pe[] = /* samsho2pe, from finalburnneo git, clone of samsho2 of course */
 {
-    LOAD_SW16( CPU1, "063-p1pe.p1",	0, 0x100000, 0x7af0612c ),
-    LOAD_SW16( CPU1, "063-p2pe.sp2",	0x100000, 0x100000, 0x5fb8a564 ),
-    LOAD_SW16( CPU1, "063-p3pe.p3",	0x200000, 0x020000, 0x74c7e103 ),
+    LOAD_SW16( CPU1, "063-p1pe.p1",	0, 0x100000, 0x82ef7872 ),
+    LOAD_SW16( CPU1, "063-p2pe.sp2",	0x100000, 0x100000, 0x48cba9cb ),
+    LOAD_SW16( CPU1, "063-p3pe.p3",	0x200000, 0x020000, 0x291dd6de ),
     ROM_END
 };
 
-CLNEI( samsho2pe, samsho2, "Samurai Shodown II / Shin Samurai Spirits - Haohmaru Jigokuhen (Perfect V. 2.0, Hack)", HACK, 2023, GAME_BEAT);
+CLNEI( samsho2pe, samsho2, "Samurai Shodown II / Shin Samurai Spirits - Haohmaru Jigokuhen (Perfect V. 2.1, Hack)", HACK, 2024, GAME_BEAT);
 
 static struct ROM_INFO rom_samsho2k[] = /* KOREAN VERSION clone of samsho2 */
 {


### PR DESCRIPTION
Updated according to the latest changes in the fbneo source.

Here are the commits:
https://github.com/finalburnneo/FBNeo/commit/fa2d9022c54085a501adb29f4dffadb79d9b2d27
https://github.com/finalburnneo/FBNeo/commit/cb77e2b44d35cf3cf376660ddd076a6b3354f731
https://github.com/finalburnneo/FBNeo/commit/134c0e9d727e00b7299fbb7f62451eccf63dd07a

The first commit states that the game no longer works with NeoGeo AES mode. Hopefully that change won't cause any issues with Raine.

The game is already updated in archive.org fbneo's romset.

The release year was also updated to 2024.