### PR TITLE
Update to samsho2pe version 2.2

### DIFF
--- a/source/games/neogeo.c
+++ b/source/games/neogeo.c
@@ -1264,13 +1264,13 @@ CLNEI( samsho2, neogeo, "Samurai Shodown II / Shin Samurai Spirits - Haohmaru ji
 
 static struct ROM_INFO rom_samsho2pe[] = /* samsho2pe, from finalburnneo git, clone of samsho2 of course */
 {
-    LOAD_SW16( CPU1, "063-p1pe.p1",	0, 0x100000, 0x82ef7872 ),
-    LOAD_SW16( CPU1, "063-p2pe.sp2",	0x100000, 0x100000, 0x48cba9cb ),
-    LOAD_SW16( CPU1, "063-p3pe.p3",	0x200000, 0x020000, 0x291dd6de ),
+    LOAD_SW16( CPU1, "063-p1pe.p1",	0, 0x100000, 0x03bfaaaf ),
+    LOAD_SW16( CPU1, "063-p2pe.sp2",	0x100000, 0x100000, 0xa3a39ea4 ),
+    LOAD_SW16( CPU1, "063-p3pe.p3",	0x200000, 0x020000, 0x82ce7ad7 ),
     ROM_END
 };
 
-CLNEI( samsho2pe, samsho2, "Samurai Shodown II / Shin Samurai Spirits - Haohmaru Jigokuhen (Perfect V. 2.1, Hack)", HACK, 2024, GAME_BEAT);
+CLNEI( samsho2pe, samsho2, "Samurai Shodown II / Shin Samurai Spirits - Haohmaru Jigokuhen (Perfect V. 2.2, Hack)", HACK, 2024, GAME_BEAT);
 
 static struct ROM_INFO rom_samsho2k[] = /* KOREAN VERSION clone of samsho2 */
 {


### PR DESCRIPTION
As per the commit in fbneo GitHub:
https://github.com/finalburnneo/FBNeo/commit/1038c90ca68bfaa5b75d10152e9a6afb1dd107c5

Ukyo Readjusted Tsubame Gaeshi Range Slash, Nerf
Cham Cham Readjusted Boomerang Range For Zoom 3.5, Nerf Readjusted Range For All Chars, Simple Attacks, A,B,AB,C,D,CD, Nerf Readjusted Range For All Chars Unnarmed, Simple Attacks, A,B,AB,C,D,CD, Nerf Reduced Velocity All Chars For Zoom 3.5, Nerf
Genan Unnarmed Jump+cd Crash Reset Game, Bug Fix
Nakoruru Unnarmed Jump+A Crash Reset Game, Bug Fix

Game has already been updated in archive.org's fbneo romset.