### PR TITLE
Renamed "Fullscreen" option to "Enable fullscreen mode (borderless window)"

### DIFF
--- a/locale/es.po
+++ b/locale/es.po
@@ -3405,8 +3405,8 @@ msgid "Fullheight + double width"
 msgstr "Alto completo + Doble ancho"
 
 #: source/sdl/dialogs/video_options.cpp:270 source/sdl/control.c:674
-msgid "Fullscreen"
-msgstr "Pantalla completa"
+msgid "Enable fullscreen mode (borderless window)"
+msgstr "Activar el modo de pantalla completa (ventana sin bordes)"
 
 #: source/sdl/dialogs/video_options.cpp:272
 #, fuzzy
@@ -6599,8 +6599,8 @@ msgid "Yes (adaptive)"
 msgstr ""
 
 #: source/sdl/dialogs/video_options.cpp:270
-msgid "Yes (desktop)"
-msgstr ""
+msgid "Yes"
+msgstr "Sí"
 
 #: source/sdl/dialogs/video_options.cpp:270
 msgid "Yes (real)"

--- a/locale/french.po
+++ b/locale/french.po
@@ -3377,8 +3377,8 @@ msgid "Fullheight + double width"
 msgstr "Pleine hauteur + double largeur"
 
 #: source/sdl/dialogs/video_options.cpp:270 source/sdl/control.c:674
-msgid "Fullscreen"
-msgstr "Plein écran"
+msgid "Enable fullscreen mode (borderless window)"
+msgstr "Activer le mode plein écran (fenêtre sans bordure)"
 
 #: source/sdl/dialogs/video_options.cpp:272
 msgid "Fullscreen hack for Intel"
@@ -6529,8 +6529,8 @@ msgid "Yes (adaptive)"
 msgstr "Oui (adaptatif)"
 
 #: source/sdl/dialogs/video_options.cpp:270
-msgid "Yes (desktop)"
-msgstr "Oui (bureau)"
+msgid "Yes"
+msgstr "Oui"
 
 #: source/sdl/dialogs/video_options.cpp:270
 msgid "Yes (real)"

--- a/locale/it.po
+++ b/locale/it.po
@@ -3572,8 +3572,8 @@ msgid "Fullheight + double width"
 msgstr "Massima altezza + Doppia larghezza"
 
 #: source/sdl/dialogs/video_options.cpp:270 source/sdl/control.c:674
-msgid "Fullscreen"
-msgstr "Schermo intero"
+msgid "Enable fullscreen mode (borderless window)"
+msgstr "Abilita la modalità a schermo intero (finestra senza bordi)"
 
 #: source/sdl/dialogs/video_options.cpp:272
 #, fuzzy
@@ -6951,8 +6951,8 @@ msgid "Yes (adaptive)"
 msgstr ""
 
 #: source/sdl/dialogs/video_options.cpp:270
-msgid "Yes (desktop)"
-msgstr ""
+msgid "Yes"
+msgstr "Sì"
 
 #: source/sdl/dialogs/video_options.cpp:270
 msgid "Yes (real)"

--- a/locale/pt_br.po
+++ b/locale/pt_br.po
@@ -3486,8 +3486,8 @@ msgid "Fullheight + double width"
 msgstr "Altura máxima + O dobro da largura"
 
 #: source/sdl/dialogs/video_options.cpp:272 source/sdl/control.c:674
-msgid "Fullscreen"
-msgstr "Tela cheia"
+msgid "Enable fullscreen mode (borderless window)"
+msgstr "Ativar o modo de tela cheia (janela sem bordas)"
 
 #: source/sdl/dialogs/video_options.cpp:274
 msgid "Fullscreen hack for Intel"
@@ -6799,8 +6799,8 @@ msgid "Yes (adaptive)"
 msgstr "Sim (adaptativo)"
 
 #: source/sdl/dialogs/video_options.cpp:272
-msgid "Yes (desktop)"
-msgstr "Sim (área de trabalho)"
+msgid "Yes"
+msgstr "Sim"
 
 #: source/sdl/dialogs/video_options.cpp:272
 msgid "Yes (real)"

--- a/source/sdl/dialogs/video_options.cpp
+++ b/source/sdl/dialogs/video_options.cpp
@@ -263,7 +263,7 @@ static menu_item_t video_items[] =
 #endif
 #endif
     // fullscreen from here is a nuisance, it's easier to handle from the keyboard handler
-{ _("Fullscreen"), &my_toggle_fullscreen, &display_cfg.fullscreen, 2, {0, 1}, {_("No"), _("Yes (desktop)"), _("Yes (real)")}},
+{ _("Enable fullscreen mode (borderless window)"), &my_toggle_fullscreen, &display_cfg.fullscreen, 2, {0, 1}, {_("No"), _("Yes)"), _("Yes (real)")}},
 #ifdef RAINE_UNIX
 { _("Fullscreen hack for Intel"), NULL, &hack_fs, 2, {0, 1}, {_("No"),_("Yes")}},
 #endif


### PR DESCRIPTION
Renamed "Fullscreen" option to "Enable fullscreen mode (borderless window)" and the setting "Yes (desktop)" to just "Yes". There is only one fullscreen mode now, so the mode description can be moved from the parameter to the setting string itself. This way we can follow other settings in the GUI with "yes" or "no" as parameters, such as "Mute music" and "Pause when focus lost". I also added a verb to comply with this standard in the interface.

The translation files were updated to match the naming changes. Hopefully everything is working fine.