### PR TITLE
Small revision to the fullscreen option in Video options and in Raine controls

### DIFF
--- a/locale/es.po
+++ b/locale/es.po
@@ -3405,8 +3405,8 @@ msgid "Fullheight + double width"
 msgstr "Alto completo + Doble ancho"
 
 #: source/sdl/dialogs/video_options.cpp:270 source/sdl/control.c:674
-msgid "Fullscreen"
-msgstr "Pantalla completa"
+msgid "Enable fullscreen mode"
+msgstr "Activar el modo de pantalla completa"
 
 #: source/sdl/dialogs/video_options.cpp:272
 #, fuzzy

--- a/locale/french.po
+++ b/locale/french.po
@@ -3377,12 +3377,12 @@ msgid "Fullheight + double width"
 msgstr "Pleine hauteur + double largeur"
 
 #: source/sdl/dialogs/video_options.cpp:270 source/sdl/control.c:674
-msgid "Fullscreen"
-msgstr "Plein Ecran"
+msgid "Enable fullscreen mode"
+msgstr "Activer le mode plein écran"
 
 #: source/sdl/dialogs/video_options.cpp:272
 msgid "Fullscreen hack for Intel"
-msgstr "hack plein écran pour intel"
+msgstr "Hack plein écran pour intel"
 
 #: source/games/toaplan2.c:272
 msgid "Fully-auto"

--- a/locale/it.po
+++ b/locale/it.po
@@ -3572,8 +3572,8 @@ msgid "Fullheight + double width"
 msgstr "Massima altezza + Doppia larghezza"
 
 #: source/sdl/dialogs/video_options.cpp:270 source/sdl/control.c:674
-msgid "Fullscreen"
-msgstr "a schermo intero"
+msgid "Enable fullscreen mode"
+msgstr "Abilita la modalità a schermo intero"
 
 #: source/sdl/dialogs/video_options.cpp:272
 #, fuzzy

--- a/locale/pt_br.po
+++ b/locale/pt_br.po
@@ -3486,8 +3486,8 @@ msgid "Fullheight + double width"
 msgstr "Altura máxima + O dobro da largura"
 
 #: source/sdl/dialogs/video_options.cpp:272 source/sdl/control.c:674
-msgid "fullscreen"
-msgstr "Tela cheia"
+msgid "Enable fullscreen mode"
+msgstr "Ativar o modo de tela cheia"
 
 #: source/sdl/dialogs/video_options.cpp:274
 msgid "Fullscreen hack for Intel"

--- a/source/sdl/control.c
+++ b/source/sdl/control.c
@@ -719,7 +719,7 @@ static void cold_boot() {
 struct DEF_INPUT_EMU def_input_emu[] =
 {
  { SDL_SCANCODE_S ,       0x00,           _("Save Screenshot"), KMOD_CTRL, key_save_screen     },
- { SDL_SCANCODE_RETURN ,       0x00,           _("Fullscreen"), KMOD_ALT, toggle_fullscreen_keyboard     },
+ { SDL_SCANCODE_RETURN ,       0x00,           _("Toggle fullscreen"), KMOD_ALT, toggle_fullscreen_keyboard     },
  { SDL_SCANCODE_PAGEUP,    0x00,           _("Increase frameskip"), 0, frame_skip_up  },
  { SDL_SCANCODE_PAGEDOWN,    0x00,           _("Decrease frameskip"), 0, frame_skip_down  },
  { SDL_SCANCODE_HOME,    0x00,           _("Increase CPU skip"),    0, cpu_speed_up},

--- a/source/sdl/dialogs/video_options.cpp
+++ b/source/sdl/dialogs/video_options.cpp
@@ -263,7 +263,7 @@ static menu_item_t video_items[] =
 #endif
 #endif
     // fullscreen from here is a nuisance, it's easier to handle from the keyboard handler
-{ _("Fullscreen"), &my_toggle_fullscreen, &display_cfg.fullscreen, 2, {0, 1}, {_("No"), _("Yes") }},
+{ _("Enable fullscreen mode"), &my_toggle_fullscreen, &display_cfg.fullscreen, 2, {0, 1}, {_("No"), _("Yes") }},
 #ifdef RAINE_UNIX
 { _("Fullscreen hack for Intel"), NULL, &hack_fs, 2, {0, 1}, {_("No"),_("Yes")}},
 #endif


### PR DESCRIPTION
I made a small revision in the fullscreen setting string to match the other string syntax we have in Raine, which is "verb + complement". Now it is named "Enable fullscreen mode" instead of just "Fullscreen". I also revised the setting in Raine controls to match that pattern.

All translation files have been revised, but I couldn't find the strings for Raine controls in those files.

Hopefully everything is right now.