### PR TITLE
Add native Apple Silicon (arm64 macOS) support

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -5,11 +5,11 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
-	<string>Raine</string>
+	<string>raine</string>
 	<key>CFBundleIconFile</key>
 	<string>new_logo</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.vim.Raine</string>
+	<string>org.rainemu.raine</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -17,16 +17,12 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.64.10</string>
-	<key>CFBundleSignature</key>
-	<string>VIMM</string>
+	<string>0.97.6</string>
 	<key>CFBundleVersion</key>
-	<string>33.3</string>
-	<key>NSMainNibFile</key>
-	<string>MainMenu</string>
-	<key>NSPrincipalClass</key>
-	<string>MMApplication</string>
-	<key>SUFeedURL</key>
-	<string>feed://rainemu.swishparty.co.uk/msgboard/yabbse/index.php?board=3.0;type=rss;action=.xml;sa=news</string>
+	<string>0.97.6</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>LSMinimumSystemVersion</key>
+	<string>11.0</string>
 </dict>
 </plist>

--- a/makefile
+++ b/makefile
@@ -182,6 +182,11 @@ else
     LD=$(CXX)
 endif
 endif
+# arm64 (Apple Silicon) : the x86_64 sysctl test above doesn't match,
+# make sure we link with the compiler driver, not raw ld
+ifeq ("$(LD)","ld")
+  LD=$(CXX)
+endif
 endif # darwin
 
 ifeq ("$(OSTYPE)","msys")
@@ -468,6 +473,9 @@ ALLEGRO_CFLAGS = "$(shell allegro-config --cflags)"
 endif
 
    INCDIR += $(PNG_CFLAGS) $(ALLEGRO_CFLAGS)
+ifdef DARWIN
+   INCDIR += -I/opt/homebrew/include
+endif
 
 
    DEFINE = -D__RAINE__ \
@@ -483,9 +491,9 @@ ifndef SDL
    LIBS_STATIC = -lz $(shell allegro-config --static) $(shell libpng-config --static --ldflags) -lm
 else
 ifdef DARWIN
-   LIBS = -lz /usr/local/lib/libpng.a -lm
-   LIBS_DEBUG = -lz /usr/local/lib/libpng.a -lm
-   LIBS_STATIC = -lz /usr/local/lib/libpng.a -lm
+   LIBS = -lz $(shell libpng-config --ldflags) -lm -L/opt/homebrew/lib -lintl -framework OpenGL
+   LIBS_DEBUG = -lz $(shell libpng-config --ldflags) -lm -L/opt/homebrew/lib -lintl -framework OpenGL
+   LIBS_STATIC = -lz $(shell libpng-config --ldflags) -lm -L/opt/homebrew/lib -lintl -framework OpenGL
 else
    LIBS = -lz $(shell libpng-config --ldflags) -lm
    LIBS_DEBUG = -lz $(shell libpng-config --ldflags) -lm
@@ -1827,7 +1835,7 @@ $(OBJDIR)/Musashi/m68kmake: $(OBJDIR)/Musashi/m68kmake.o
 ifdef CROSSCOMPILE
 	cp -fv $(NATIVE)/object/Musashi/m68kmake $(OBJDIR)/Musashi || cp -fv $(NATIVE)/objectd/Musashi/m68kmake $(OBJDIR)/Musashi
 else
-	$(LD) -o $@ $<
+	$(CC) -o $@ $<
 endif
 
 $(OBJDIR)/Musashi/m68kcpu.o: source/Musashi/m68kops.h source/Musashi/m68kops.c source/Musashi/m68kcpu.c

--- a/makefile
+++ b/makefile
@@ -1787,7 +1787,7 @@ else
 		bitmaps/controllermap.bmp bitmaps/controllermap_back.bmp $(bitmaps_dir)
 	@echo installing shaders in $(shaders_dir)
 	$(INSTALL_DATA) shaders/*.shader $(shaders_dir)
-	@cp -rfva scripts/* $(scripts_dir)
+	@cp -Rfv scripts/* $(scripts_dir)
 	$(INSTALL_DATA) gamecontrollerdb.txt $(rainedata)
 	$(INSTALL_DATA) command.dat $(rainedata)
 #	$(INSTALL_DATA) blend/* $(bld_dir)

--- a/source/Musashi/m68kcpu.h
+++ b/source/Musashi/m68kcpu.h
@@ -67,6 +67,12 @@ extern "C" {
 #undef sint
 #undef uint
 
+#ifdef __APPLE__
+/* macOS sys/types.h typedefs uint; pull it in now so the include guard
+   prevents it being parsed again after uint is macro-defined below */
+#include <sys/types.h>
+#endif
+
 #define sint8  signed   char			/* ASG: changed from char to signed char */
 #define sint16 signed   short
 #define sint32 signed   int			/* AWJ: changed from long to int */

--- a/source/games/games.c
+++ b/source/games/games.c
@@ -133,7 +133,11 @@ static void init_recent() {
 		ret = stat(s,&buf);
 	    }
 	    if (!ret) {
+#ifdef __APPLE__
+		game_list[n]->last_played = buf.st_atimespec.tv_sec;
+#else
 		game_list[n]->last_played = buf.st_atim.tv_sec;
+#endif
 	    }
 	}
     }

--- a/source/gens_sh2/sh2.h
+++ b/source/gens_sh2/sh2.h
@@ -1,7 +1,7 @@
 /**********************************************************/
 /*                                                        */
 /* SH2 emulator 1.40 (Hearder part)                       */
-/* Copyright 2002 Stéphane Dallongeville                  */
+/* Copyright 2002 Stï¿½phane Dallongeville                  */
 /* Used for the 32X emulation in Gens                     */
 /*                                                        */
 /**********************************************************/
@@ -31,8 +31,14 @@
 
 #else //__GNUC__
 
+#if defined(__i386__) || defined(__x86_64__)
 #define FASTCALL __attribute__ ((regparm(2)))
 #define DECL_FASTCALL(type, name)	type name __attribute__ ((regparm(2)))
+#else
+/* regparm is x86-only; no-op on arm64 and other architectures */
+#define FASTCALL
+#define DECL_FASTCALL(type, name)	type name
+#endif
 
 #endif //!__GNUC__
 

--- a/source/mame/memory.h
+++ b/source/mame/memory.h
@@ -9,7 +9,11 @@ extern "C" {
     // There is a way to test endianness with sdl, but including SDL.h slows noticeably down the compilation
     // and it's not the case with endian.h... now I hope it's windows compatible... !
 #ifdef RAINE_UNIX
+#ifdef __APPLE__
+#include <machine/endian.h>
+#else
 #include <endian.h>
+#endif
 #else
 #ifdef RAINE_WIN32
 #include <sys/param.h>

--- a/source/mame/sh2/sh2.h
+++ b/source/mame/sh2/sh2.h
@@ -40,8 +40,14 @@
 #else //__GNUC__
 
 #undef FASTCALL
+#if defined(__i386__) || defined(__x86_64__)
 #define FASTCALL __attribute__ ((regparm(2)))
 #define DECL_FASTCALL(type, name)	type name __attribute__ ((regparm(2)))
+#else
+/* regparm is x86-only; no-op on arm64 and other architectures */
+#define FASTCALL
+#define DECL_FASTCALL(type, name)	type name
+#endif
 
 #endif //!__GNUC__
 

--- a/source/mini-unzip/ioapi.c
+++ b/source/mini-unzip/ioapi.c
@@ -16,7 +16,7 @@
 
 #include "ioapi.h"
 
-#if defined(DARWIN) || defined(ANDROID)
+#if defined(DARWIN) || defined(ANDROID) || defined(__APPLE__)
 #define fopen64 fopen
 #define ftello64 ftello
 #define fseeko64 fseeko

--- a/source/mini-unzip/ioapi.h
+++ b/source/mini-unzip/ioapi.h
@@ -49,6 +49,12 @@
 #define ftello64 ftell
 #define fseeko64 fseek
 #else
+#ifdef __APPLE__
+ /* macOS stdio is 64-bit by default; the *64 variants don't exist */
+ #define fopen64 fopen
+ #define ftello64 ftello
+ #define fseeko64 fseeko
+#endif
 #ifdef _MSC_VER
  #define fopen64 fopen
  #if (_MSC_VER >= 1400) && (!(defined(NO_MSCVER_FILE64_FUNC)))

--- a/source/sdl/control.c
+++ b/source/sdl/control.c
@@ -24,6 +24,7 @@
 */
 
 #include <SDL.h>
+#include <limits.h>
 #include "deftypes.h"
 #include "games.h"
 #include "control.h"

--- a/source/sdl2/profile.c
+++ b/source/sdl2/profile.c
@@ -229,6 +229,13 @@ void UpdateProfile(void)
 
 #endif
 
+#ifndef RDTSC_PROFILE
+/* No rdtsc instruction on this architecture (e.g. arm64) :
+   profiling sections become no-ops */
+void ProfileStart(UINT8 mode) { (void)mode; }
+void ProfileStop(UINT8 mode) { (void)mode; }
+#endif
+
 static void update_fps(int quiet)
 {
   if(raine_cfg.show_fps_mode>4) raine_cfg.show_fps_mode=0;


### PR DESCRIPTION
This adds native Apple Silicon (arm64 macOS) support. With these changes the current tree builds and runs with `make NO_ASM=1` on an M-series Mac with Homebrew-provided dependencies (sdl2, sdl2_image, sdl2_ttf, gettext, lua, libpng), and `make install` produces a working Raine.app bundle.

Summary of changes, one commit each:

1. **makefile** — link `m68kmake` and the final binary with the compiler driver instead of raw `ld` (macOS `ld` doesn't add libc; the existing `LD=ld` fallback was only reachable in the non-Darwin branch); replace the hardcoded `/usr/local/lib/libpng.a` with `libpng-config` so it works on both Intel (`/usr/local`) and Apple Silicon (`/opt/homebrew`) Homebrew; add `-lintl` (gettext is not in libc on macOS) and `-framework OpenGL` (no `-lGL` on macOS).

2. **x86-only constructs** — `__attribute__((regparm(2)))` in both SH2 cores is now guarded to x86/x86_64 (it's a hard error on arm64 clang); `ProfileStart`/`ProfileStop` get no-op stubs when `RDTSC_PROFILE` is undefined — on x86_64 the `__MMX__` test in raine.h keeps it enabled even with NO_ASM, but arm64 has no rdtsc at all, and sasound.c calls these unconditionally.

3. **Darwin/POSIX portability** — include `sys/types.h` before the `uint` macro in Musashi's m68kcpu.h (macOS typedefs `uint`, and the macro corrupted the typedef when zlib.h pulled it in later); `machine/endian.h` on macOS; map `fopen64`/`ftello64`/`fseeko64` via `__APPLE__` (the existing `DARWIN` test in ioapi.c is never passed by the makefile, and macOS stdio is 64-bit by default); `st_atimespec` instead of `st_atim`; include `limits.h` for PATH_MAX in sdl/control.c.

4. **macOS packaging** — `cp -Rfv` instead of `cp -rfva` in `make install` (BSD cp rejects `-r` with `-a`); refresh Info.plist, which was old MacVim boilerplate (org.vim bundle id, MMApplication, version 0.64.10, and `CFBundleExecutable` "Raine" vs the installed "raine"), and add `NSHighResolutionCapable` so SDL2 renders at native Retina resolution.

Tested on macOS 15 (Darwin 25.5.0) / Apple clang 21 / M-series: full build, `-gamelist` (1083 games), GUI launch both from the shell and via the Raine.app bundle from Finder. Linux should be unaffected — all changes are behind `__APPLE__`/architecture guards or are flag-compatible with GNU tools, except the `cp` flag change which drops `-a`'s permission-preserving behaviour for installed scripts (they're installed user-readable either way).
