### PR TITLE
macOS arm64: define DARWIN + fix GUI black screen (follow-up to #79)

### DIFF
--- a/makefile
+++ b/makefile
@@ -481,6 +481,12 @@ endif
    DEFINE = -D__RAINE__ \
 	   -DRAINE_UNIX
 
+ifdef DARWIN
+   # source files test #ifdef DARWIN (bundle paths in raine.c, video, 7z...)
+   # but nothing ever passed it to the compiler
+   DEFINE += -DDARWIN
+endif
+
 ifdef USE_MEMWATCH
 	DEFINE += -DMEMWATCH -DMW_STDIO
 endif

--- a/source/raine.c
+++ b/source/raine.c
@@ -382,14 +382,6 @@ int main(int argc,char *argv[])
        // If lauched from a bundle the share path becomes the Ressources dir
        strncpy(dir_cfg.share_path,argv[0],256);
        strcpy(dir_cfg.share_path+(s - argv[0]),"Resources/");
-       strncpy(dir_cfg.m68kdis,argv[0],256);
-       strncpy(dir_cfg.dz80,argv[0],256);
-       strcpy(dir_cfg.m68kdis+(s - argv[0]+6),"m68kdis");
-       strcpy(dir_cfg.dz80+(s - argv[0]+6),"dz80");
-       if (!exists(dir_cfg.m68kdis))
-	   strcpy(dir_cfg.m68kdis,"m68kdis");
-       if (!exists(dir_cfg.dz80))
-	   strcpy(dir_cfg.dz80,"dz80");
    }
 #endif
 
@@ -723,7 +715,7 @@ int main(int argc,char *argv[])
 	"\n"
 	"ISSUES:\n"
 	"\n"
-	"þ This is an alpha release - I expect there are bugs and the\n"
+	"ï¿½ This is an alpha release - I expect there are bugs and the\n"
 	"  docs are a bit out of date. This is due to lack of time, a\n"
 	"  problem that will effect raine for these last few days of\n"
 	"  it's life.\n"

--- a/source/sdl/opengl.c
+++ b/source/sdl/opengl.c
@@ -191,6 +191,19 @@ static const char* myglGetString( GLenum id) {
 }
 
 void get_ogl_infos() {
+#if SDL == 2
+	/* ScreenChange calls this before opengl_reshape has created the
+	 * context. On linux gl calls without a current context are no-ops,
+	 * on macOS they crash (SIGSEGV in the CGL dispatch), so make sure
+	 * the context exists before any gl call. */
+	if (!context) {
+	    context = SDL_GL_CreateContext(win);
+	    if (!context) {
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_GL_CreateContext(): %s\n", SDL_GetError());
+		exit(2);
+	    }
+	}
+#endif
 	check_error("start ogl_infos");
 	int format_error = 0;
 #if SDL==1

--- a/source/sdl2/blit.c
+++ b/source/sdl2/blit.c
@@ -220,16 +220,6 @@ void ReClipScreen(void)
 	 bezel_fix_screen_size(&xxx2,&yyy2);
 	 bezel_fix_screen_coordinates(&destx2,&desty2,xxx2,yyy2,display_cfg.screen_x,display_cfg.screen_y);
 #endif
-#ifdef DARWIN
-	 if (display_cfg.video_mode == 1 && overlays_workarounds) {
-	     // I have a bug here which makes the overlay invisible if it doesn't start
-	     // at the top of the screen !!!
-	     // It seems so stupid that it's probably a bug of my video driver, but to
-	     // be sure I'll put a fix here, it's better than a black screen...
-	     area_overlay.x = destx2 = 0;
-	     area_overlay.y = desty2 = 0;
-	 }
-#endif
 	 if (display_cfg.keep_ratio) {
 	     area_overlay.x = destx2;
 	     area_overlay.y = desty2;

--- a/source/sdl2/compat.c
+++ b/source/sdl2/compat.c
@@ -215,6 +215,13 @@ void  sdl_init() {
 	// Must be set before creating the renderer
 	SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
 #else
+#ifdef DARWIN
+	// The gui uses the sdl renderer while the game blitter drives a raw
+	// opengl context on the same window. On macOS the renderer defaults
+	// to metal, which can't share the window with an opengl context and
+	// everything renders black, so force the opengl renderer like win32.
+	SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
+#endif
 	if (!testing_game && display_cfg.fullscreen && !hack_fs)
 	    SDL_SetWindowFullscreen(win,SDL_WINDOW_FULLSCREEN_DESKTOP);
 #endif


### PR DESCRIPTION
Follow-up to #79 — two macOS fixes that were committed after that PR was opened and so didn't make it into the squashed merge. These are runtime fixes found when testing the GUI on Apple Silicon (the build-only fixes are already in #79).

**1. Actually define `DARWIN`, and drop two dead `#ifdef DARWIN` blocks**
The source has `#ifdef DARWIN` blocks (notably the bundle `Resources/` path logic in `raine.c`) but the makefile never passed `-DDARWIN`, so they never compiled in — the app couldn't locate its data files when launched as a `.app`. Defining it surfaced two blocks that had bit-rotted while dormant:
- `raine.c` set `dir_cfg.m68kdis` / `.dz80`, fields removed from `struct DIR_CFG` long ago — dropped, keeping the `share_path` logic that makes bundle launch work.
- `sdl2/blit.c` referenced `overlays_workarounds`, an SDL1-only global absent from the SDL2 build — the whole block was a no-op workaround for an old driver bug, removed.

**2. Fix black screen and a first-frame crash in the GUI**
- `opengl.c`: `ScreenChange()` → `get_ogl_infos()` makes GL calls before `opengl_reshape()` creates the context. On Linux a call with no current context is a silent no-op; on macOS it dereferences a null dispatch table and segfaults on the first frame. Create the context up front in `get_ogl_infos`.
- `compat.c`: the GUI draws via the SDL renderer while the blitter drives a raw OpenGL context on the same window. macOS defaults the renderer to Metal, which can't coexist with the GL context, so the whole window renders black. Force the `opengl` render driver on Darwin, exactly as the existing win32 path does.

Tested on macOS 15 (Darwin 25.5.0) / Apple clang / M-series: builds with `make NO_ASM=1`, GUI renders, runs from both the shell and the `.app` bundle.
