### PR TITLE
macOS arm64: renderer selection + fullscreen fixes (follow-up to #80)

### DIFF
--- a/source/display.h
+++ b/source/display.h
@@ -14,6 +14,7 @@ extern int hack_fs;
 
 void display_read_config();
 void display_write_config();
+extern int pending_video_mode; // parked renderer change, applied next launch
 void load_screen_settings(char *section);
 void save_screen_settings(char *section);
 

--- a/source/sdl/control.c
+++ b/source/sdl/control.c
@@ -437,17 +437,8 @@ static void toggle_limit_speed() {
 extern void key_stop_emulation_esc(void);
 extern void key_stop_emulation_tab(void);
 
-void toggle_fullscreen() {
-    if (display_cfg.maximized) return; // too crazy in windows if window is maximized
-				       // you are almost sure to loose pos, size or both
-#if SDL == 1
-  resize(1);
-  SetupScreenBitmap();
-  if (current_game) {
-    init_video_core();
-    reset_ingame_timer();
-  }
-#else
+#if SDL != 1
+static void apply_fullscreen(void) {
   // For some totally unknown reason, SDL_SetWindowFullscreen here is totally broken on my laptop but works on my desktop !
   // they both have very similar software configuration, windowmaker, same xorg, just the desktop uses some nvidia card and the laptop an intel
   // anyway the problem is the window receives quite a few events when going to fullscreen, in the end it's minimized and hidden, and bye bye, if I try to force call
@@ -468,7 +459,10 @@ void toggle_fullscreen() {
       SDL_SetWindowFullscreen(win,SDL_WINDOW_FULLSCREEN);
   } else {
       SDL_SetWindowFullscreen(win,0);
-#ifndef RAINE_WIN32
+#if !defined(RAINE_WIN32) && !defined(DARWIN)
+      // macOS native fullscreen restores the pre-fullscreen frame itself on
+      // exit; forcing size/position here races that async transition and
+      // can leave the window the wrong size or borderless.
       SDL_SetWindowSize(win,display_cfg.prev_sx,display_cfg.prev_sy);
       SDL_SetWindowPosition(win,display_cfg.posx,display_cfg.posy);
 #endif
@@ -485,11 +479,33 @@ void toggle_fullscreen() {
       display_cfg.prev_posy = display_cfg.posy;
   }
   ScreenChange();
+}
+#endif
+
+void toggle_fullscreen() {
+#ifndef DARWIN
+    if (display_cfg.maximized) return; // too crazy in windows if window is maximized
+				       // you are almost sure to loose pos, size or both
+#endif
+    // On macOS a screen-covering window can make the OS post spurious
+    // MAXIMIZED events; gating the toggle on display_cfg.maximized would
+    // jam fullscreen permanently after one cycle, so don't gate it here.
+#if SDL == 1
+  resize(1);
+  SetupScreenBitmap();
+  if (current_game) {
+    init_video_core();
+    reset_ingame_timer();
+  }
+#else
+  apply_fullscreen();
 #endif
 }
 
 static void toggle_fullscreen_keyboard() {
+#ifndef DARWIN
     if (display_cfg.maximized) return;
+#endif
   if (display_cfg.fullscreen) {
     display_cfg.fullscreen = 0;
   } else {
@@ -1945,7 +1961,13 @@ void control_handle_event(SDL_Event *event) {
       else if (event->window.event == SDL_WINDOWEVENT_FOCUS_LOST)
 	  display_cfg.lost_focus = 1;
       if (event->window.event == SDL_WINDOWEVENT_MAXIMIZED) {
-	  display_cfg.maximized = 1;
+	  // A screen-covering fullscreen window (macOS) can make the OS post a
+	  // spurious MAXIMIZED event. Treating that as "maximized" latches
+	  // display_cfg.maximized=1, which then blocks every further fullscreen
+	  // toggle (toggle_fullscreen early-returns and the menu item becomes
+	  // unselectable). A fullscreen window is never maximized.
+	  if (!display_cfg.fullscreen)
+	      display_cfg.maximized = 1;
       } else if (event->window.event == SDL_WINDOWEVENT_MINIMIZED) {
 	  display_cfg.maximized = 2;
       } else if (event->window.event == SDL_WINDOWEVENT_RESTORED) {

--- a/source/sdl/dialogs/video_options.cpp
+++ b/source/sdl/dialogs/video_options.cpp
@@ -31,8 +31,12 @@ class TVideo : public TMenu
     TMenu(my_title,mymenu)
     {}
   int can_be_selected(int n) {
+#ifndef DARWIN
       if (n == 1) // fullscreen
         return (display_cfg.maximized == 0);
+      // On macOS the borderless fullscreen window posts spurious MAXIMIZED
+      // events, so don't make the Fullscreen item unselectable from that.
+#endif
       return TMenu::can_be_selected(n);
   }
 };
@@ -295,9 +299,32 @@ int do_video_options(int sel) {
 #endif
 #endif
     // int oldx = display_cfg.screen_x,oldy = display_cfg.screen_y;
+#ifdef DARWIN
+    // The SDL window and renderer are created once at startup for the chosen
+    // mode (opengl needs a GL window + opengl renderer; SDL2-native uses
+    // metal) and can't be swapped on a live window on macOS. If the menu wrote
+    // straight to display_cfg.video_mode, a redraw while still in the menu
+    // would take the GL path on a metal window and abort the app. So bind the
+    // "Video renderer" item to a scratch variable; the live video_mode never
+    // changes mid-session, and any new choice is parked for the next launch.
+    static int menu_video_mode;
+    menu_video_mode = display_cfg.video_mode;
+    for (menu_item_t *it = video_items; it->label; it++)
+	if (it->value_int == (int*)&display_cfg.video_mode) { it->value_int = &menu_video_mode; break; }
+#endif
     video_options = new TVideo("", video_items);
     video_options->execute();
     delete video_options;
+#ifdef DARWIN
+    for (menu_item_t *it = video_items; it->label; it++)
+	if (it->value_int == &menu_video_mode) { it->value_int = (int*)&display_cfg.video_mode; break; }
+    if (menu_video_mode != (int)display_cfg.video_mode) {
+	pending_video_mode = menu_video_mode;
+	raine_mbox(_("Restart required"),
+		_("The video renderer change will take effect\nnext time you start Raine."),
+		_("OK"));
+    }
+#endif
 #if defined(RAINE_WIN32) && SDL==1
     if (old_driver != display_cfg.video_driver) {
 	if (sdl_overlay) {

--- a/source/sdl2/compat.c
+++ b/source/sdl2/compat.c
@@ -216,11 +216,16 @@ void  sdl_init() {
 	SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
 #else
 #ifdef DARWIN
-	// The gui uses the sdl renderer while the game blitter drives a raw
-	// opengl context on the same window. On macOS the renderer defaults
-	// to metal, which can't share the window with an opengl context and
-	// everything renders black, so force the opengl renderer like win32.
-	SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
+	// Only the OpenGL video mode needs the opengl SDL renderer: there the
+	// game blitter drives a raw opengl context on the same window, and the
+	// macOS default (metal) renderer can't share the window with it, so
+	// everything renders black. In the SDL2-native video mode (the macOS
+	// default) there is no raw GL context, so leave the renderer on metal:
+	// the opengl renderer's framebuffer render-targets fail
+	// (glFramebufferTexture2DEXT) after a fullscreen transition, which
+	// breaks the GUI; metal render-targets don't have that problem.
+	if (display_cfg.video_mode == 0)
+	    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
 #endif
 	if (!testing_game && display_cfg.fullscreen && !hack_fs)
 	    SDL_SetWindowFullscreen(win,SDL_WINDOW_FULLSCREEN_DESKTOP);

--- a/source/sdl2/display.c
+++ b/source/sdl2/display.c
@@ -36,7 +36,16 @@ int hack_fs;
 
 void display_read_config() {
    hack_fs = raine_get_config_int( "Display", "hack_fs", 0); // hack_fs : don't call SDL_SetWindowFullscreen
+#ifdef DARWIN
+   // On macOS default to the SDL2 native renderer. The OpenGL video mode
+   // runs Raine's own GL context alongside SDL's renderer on the same
+   // window; macOS handles that badly (black screen, render-target failures
+   // in the GUI after fullscreen/resize). The SDL2 renderer has none of
+   // those problems. OpenGL mode stays selectable for GLSL shaders.
+   display_cfg.video_mode = raine_get_config_int( "Display", "video_mode", 3);
+#else
    display_cfg.video_mode = raine_get_config_int( "Display", "video_mode", 0); // default = opengl, the most tested
+#endif
    if (display_cfg.video_mode != 0 && display_cfg.video_mode != 3)
        display_cfg.video_mode = 3;
    int x = 0,y = 0;
@@ -86,10 +95,17 @@ void set_opengl_filter(int filter) {
 	ogl.filter = GL_NEAREST; // default
 }
 
+// When the video renderer is changed at runtime it can't be applied to the
+// live session (the SDL window/renderer are created once at startup), so the
+// new value is parked here and written to the config on exit, to take effect
+// at the next launch. -1 means "no pending change".
+int pending_video_mode = -1;
+
 void display_write_config() {
 
    raine_set_config_int("Display", "hack_fs", hack_fs);
-   raine_set_config_int("Display", "video_mode", display_cfg.video_mode);
+   raine_set_config_int("Display", "video_mode",
+	   pending_video_mode >= 0 ? pending_video_mode : display_cfg.video_mode);
    print_debug("display_write_config: screen_x %d screen_y %d\n",display_cfg.screen_x,display_cfg.screen_y);
    raine_set_config_int("Display", "screen_x", display_cfg.screen_x);
    raine_set_config_int("Display", "screen_y", display_cfg.screen_y);
@@ -171,14 +187,27 @@ SDL_Texture *game_tex;
 
 void ScreenChange(void)
 {
-    get_ogl_infos();
+    // get_ogl_infos()/opengl_reshape() set up Raine's raw GL context, which is
+    // only used by the OpenGL video mode's blitter. In the SDL2-native video
+    // mode there is no raw GL context (and on macOS the window may be a metal
+    // window, where creating one fails), so skip them.
+    if (display_cfg.video_mode == 0)
+	get_ogl_infos();
     int w,h;
     SDL_GetRendererOutputSize(rend,&w,&h);
     ReClipScreen();
     if (sdl_screen) {
 	sdl_screen->w = w; sdl_screen->h = h;
     }
-    opengl_reshape(w,h);
+    if (display_cfg.video_mode == 0) {
+	opengl_reshape(w,h);
+	// opengl_reshape() makes Raine's raw GL context current, which steals
+	// the current context from the SDL renderer. On macOS the next
+	// render-target bind (update_fg_layer) then fails with
+	// glFramebufferTexture2DEXT. Bind the default target to force the
+	// renderer's own context current again.
+	SDL_SetRenderTarget(rend, NULL);
+    }
 }
 
 int resize(int call,int sx,int sy) {


### PR DESCRIPTION
Follow-up to #79 / #80 — the macOS rendering and fullscreen fixes, found by actually running the GUI and games on Apple Silicon (macOS 15, M-series). Three commits:

**1. Default to the SDL2-native renderer, pick the render driver per mode**
The OpenGL video mode runs Raine's own raw GL context alongside SDL's renderer on one window, which macOS handles badly: the SDL renderer has to be forced to `opengl` (its metal default renders black when a GL context shares the window), and even then the opengl renderer's framebuffer render-targets fail (`glFramebufferTexture2DEXT`) after a fullscreen/resize, breaking the GUI. So: default to the SDL2-native video mode on macOS (no raw GL context, none of those problems; OpenGL stays selectable for GLSL shaders), only force the opengl render driver when `video_mode==0`, and skip `get_ogl_infos()`/`opengl_reshape()` in `ScreenChange()` when not in OpenGL mode (on a metal window, creating a GL context aborts the app).

**2. Fix the fullscreen toggle**
Exit left the window the wrong size or borderless because the explicit `SetWindowSize`/`SetWindowPosition` raced macOS's async native-fullscreen restore — skip them on macOS and let AppKit restore the frame. And after one fullscreen cycle the toggle jammed: a screen-covering window can make macOS post a spurious `MAXIMIZED` event, latching `display_cfg.maximized=1`, which made `toggle_fullscreen()` early-return and the menu's Fullscreen item unselectable — don't latch it while fullscreen, and don't gate the toggle on it on macOS.

**3. Renderer change requires a restart instead of crashing**
The SDL window/renderer are created once at startup for the chosen mode and can't be swapped on a live window on macOS; switching at runtime made the GUI try to create a GL context on a metal window and abort. The "Video renderer" menu item is now bound to a scratch variable so the live `video_mode` never changes mid-session; the new choice is parked (`pending_video_mode`) to be written to the config on exit, with a "restart required" message.

Result on macOS: SDL2-native mode is rock-solid (games, fullscreen, resize), and OpenGL mode from a fresh start runs games with GLSL shaders in fullscreen (verified with bublbobl + a CRT shader). All changes are behind `#ifdef DARWIN` or the existing `video_mode` checks, so other platforms are unaffected. Builds with `make NO_ASM=1`.
